### PR TITLE
Added compatibility with PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "ext-curl": "*",
         "ext-json": "*",
         "php": "^7.2|^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "symfony/http-client": "^6.0"
+        "ext-json": "*",
+        "php": "^7.2|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Flowframe\Previewify\Exception;
+
+class InvalidRequestException extends \Exception
+{
+}


### PR DESCRIPTION
To be most compatible with WordPress the best minimum php version is 7.2. Because `symfony/http` requires at least `8.0` this package also requires at least `8.0`. 

I've removed the need for the HTTP client by using cUrl for the request. This does however change the return type to a `string`, makeing it a breaking change. But isn't this SDK still a WIP? 😉 

Now the `image()` will simply return the url of the image; or thows an `InvalidRequestException` if there was an error. But it's also possible to return the decoded `object` so extra data can be added in the future; without making it breaking again. In that case someone needs to use `$object->url`.

```php
$sdk = new \Flowframe\Previewify\Previewify($key);
try {
    $response = $sdk->image(787, []);
    var_dump($response); // (string) https://.....
} catch (\Flowframe\Previewify\Exception\InvalidRequestException $exception) {
    var_dump($exception->getMessage()); //Missing fields: ...
}
```